### PR TITLE
Embed videos, e.g., for tutorials

### DIFF
--- a/content/resources/tutorials/formexportimport.md
+++ b/content/resources/tutorials/formexportimport.md
@@ -40,6 +40,6 @@ At this point I can use the form as-is. I can also add, delete, or modify fields
 
 ## Screencast
 
-This screencast walks through the process of exporting and importing a dataset form. Click on the still below to watch the screen cast (opens in a new window).
+This screencast walks through the process of exporting and importing a dataset form.
 
-[![Still from the export and import tutorial screencast Watch screencast.](/tutorials/FormImportExport-Thumb.png) Watch screencast.](/tutorials/FormImportExport.mp4)
+{{< video src="/tutorials/FormImportExport.mp4" >}}

--- a/themes/datascribe/layouts/shortcodes/video.html
+++ b/themes/datascribe/layouts/shortcodes/video.html
@@ -1,0 +1,4 @@
+<video class="video-embed" preload="auto" controls>
+	<source src="{{ .Get "src" }}" type="{{ .Get "type" }}">
+	Your browser does not support video embedding. You can <a href='{{ .Get "src" }}'>download the video</a> instead.
+</video>

--- a/themes/datascribe/static/css/style.css
+++ b/themes/datascribe/static/css/style.css
@@ -227,3 +227,8 @@ footer .logos img {
 .pagelist a{
     font-weight:400;
 }
+
+/* Embedded videos */
+video.video-embed {
+  max-width: 100%;
+}


### PR DESCRIPTION
@mebrett Here is a pull request that embeds videos. It will merge into the tutorials branch.

It should feature some basic accessibility: i.e., if the user's browser does not support video, it will automatically supply a link to download it instead with some generic text. 

I didn't think a caption was necessary, since the surrounding text provides that, but it could easily be wrapped in  `<figure>` `<figcaption>` tags if you want.