### PR TITLE
Merge cicd-workflow into main

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,0 +1,26 @@
+name: "[datascribe-site] Build, Release, Deploy"
+
+on:
+  push:
+    branches:
+      - "main"
+      - "cicd-workflow"
+    paths:
+      - "**"
+
+jobs:
+  hugo-build-release-deploy:
+    uses: chnm/.github/.github/workflows/hugo--build-release-deploy.yml@main
+    secrets: inherit
+    with:
+      container-registry: "ghcr.io"
+      container-image-name: "datascribe-site"
+      hugo-context-root: "."
+      hugo-devl-url: "https://datascribe.tech"
+      hugo-prod-url: "https://datascribe.tech"
+      
+      build-artifact-name: "datascribe-website"
+      release-tag-name-type: "iso"
+      
+      website-devl-fqdn: "datascribe.tech"
+      website-prod-fqdn: "datascribe.tech"

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - "main"
-      - "cicd-workflow"
     paths:
       - "**"
 

--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,4 @@ build :
 	hugo --cleanDestinationDir --buildDrafts --buildFuture --baseURL https://datascribe.tech/
 	@echo "Website finished building."
 
-deploy : build
-	@echo "\nDeploying the site with rsync ..."
-	rsync --delete --itemize-changes --omit-dir-times \
-		--checksum -avz --no-t --no-perms --exclude-from=rsync-excludes \
-		public/ susanoo:/websites/datascribe.tech/public | egrep -v '^\.'
-	@echo "Finished deploying the site with rsync."
-
 .PHONY : preview build deploy

--- a/rsync-excludes
+++ b/rsync-excludes
@@ -1,3 +1,0 @@
-.htaccess
-.htpasswd
-.DS_Store


### PR DESCRIPTION
Onboarding `datascribe-site` repo to use monolithic reusable workflow `hugo--build-release-deploy.yml`.

@hepplerj, this PR when merged, and if it works, will enable an end to end CI/CD pipeline where any commits to `main` will build, release, **and deploy** to target host server automatically without any manual input.