### PR TITLE
Merge matomo-tracking-js into main

### DIFF
--- a/themes/datascribe/layouts/partials/head.html
+++ b/themes/datascribe/layouts/partials/head.html
@@ -8,4 +8,22 @@
     <link href="https://fonts.googleapis.com/css2?family=Share+Tech&display=swap" rel="stylesheet"> 
     <link rel="stylesheet" href="{{ .Site.BaseURL }}/css/foundation.css">
     <link rel="stylesheet" href="{{ .Site.BaseURL }}/css/style.css">
+    
+    {{ if eq hugo.Environment "production" }}
+    <!-- Matomo -->
+    <script>
+      var _paq = window._paq = window._paq || [];
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(['trackPageView']);
+      _paq.push(['enableLinkTracking']);
+      (function() {
+        var u="https://stats.rrchnm.org/";
+        _paq.push(['setTrackerUrl', u+'matomo.php']);
+        _paq.push(['setSiteId', '107']);
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+        g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+      })();
+    </script>
+    <!-- End Matomo Code -->
+    {{ end }}
 </head>


### PR DESCRIPTION
adds matomo tracking js code before end of head tag.
should only be generated for production builds.